### PR TITLE
balance/ change ras and revert weapon changes

### DIFF
--- a/units/INU0001/INU0001_unit.bp
+++ b/units/INU0001/INU0001_unit.bp
@@ -162,8 +162,8 @@ UnitBlueprint {
         AirThreatLevel = 0,
         ArmorType = 'Commander',
         EconomyThreatLevel = 5,
-        Health = 9500,
-        MaxHealth = 9500,
+        Health = 10500,
+        MaxHealth = 10500,
         RegenRate = 15,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 75,
@@ -631,15 +631,15 @@ UnitBlueprint {
             Slot = 'Back',
         },
         ResourceAllocation = {
-            BuildCostEnergy = 150000,
+            BuildCostEnergy = 175000,
             BuildCostMass = 5000,
-            BuildTime = 1000,
+            BuildTime = 2800,
             CapacitorNewChargeTime = 20,
             CapacitorNewEnergyDrainPerSecond = 100,
             Icon = 'isb',
             Name = '<LOC enhancements_0045>Resource Allocation System',
-            ProductionPerSecondEnergy = 2800,
-            ProductionPerSecondMass = 17,
+            ProductionPerSecondEnergy = 1400,
+            ProductionPerSecondMass = 20,
             ShowBones = {
                 'upgrade_back',
             },
@@ -882,7 +882,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 0.666, -- =1,5s 100dps
+            RateOfFire = 0.6, -- =1,7s 88dps
             ReceiveROFBuff = true,
             SlavedToBody = false,
             TargetCheckInterval = 0.5,
@@ -1053,7 +1053,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 0.3,
+            RateOfFire = 0.25,
             SlavedToBody = false,
             TargetCheckInterval = 0.1,
             TargetPriorities = {


### PR DESCRIPTION
* rouge + bulfrog + acu

Bullfrog - veterancy regen + regen optimalization

rouge - nerf dps was think that it was litle bit too strong, so rather
have it weak as op

ACU
-- oc is big problem so hot fix is reduce number of shots, and decrese
aoe but will need make proper fix, best is get get back and move into
capacitator funciton
-- change muzzle to acu to fit into fa
-- change rof to have 100dps insted of 88
decrese hp whie it still too strong (problem with gun that half rof
while now its 1,5:2=0,75=0,8=>187,5dps insted of 200.   Have number for
new gun but it will be later. this is kinda hot fix.
fix all upgrade values to fit into faf patches.  But some of them will
be changed later.

* Acu RAS fit into faf balance + revert hp/weapon change for now

RAS gain most of mass to produce so lovely spamm and little energy.
Instead of aeon/sera dont have advanced version, but otherwise its best
ras.

And revert weapon change while it will be redig in future and now can
cause more problems as solve.