### PR TITLE
fix/ T1 mex increse build rate to fit into faf

### DIFF
--- a/units/INB1102/INB1102_unit.bp
+++ b/units/INB1102/INB1102_unit.bp
@@ -96,7 +96,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 360,
         BuildCostMass = 36,
-        BuildRate = 10,
+        BuildRate = 13.01,
         BuildTime = 60,
         BuildableCategory = {
             'inb1202',


### PR DESCRIPTION
i was owersee that crazy build rate number what normal faf use, this fix
issue with t2 mex upgrade slower as other factions.

#163