### PR TITLE
T3 bomber dmg increse

### DIFF
--- a/units/INA3004/INA3004_unit.bp
+++ b/units/INA3004/INA3004_unit.bp
@@ -1,3 +1,5 @@
+-- T3 strategic bomber 
+
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
@@ -294,7 +296,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_None',
             BombDropThreshold = 3.5,
             CollideFriendly = false,
-            Damage = 75,
+            Damage = 150,
             DamageFriendly = true,
             DamageRadius = 8,
             DamageType = 'Normal',


### PR DESCRIPTION
#162 It have wrong number by my mistake.
Should be 1000(burst)+1500(ower 2 sec) dmg on higer aoe as cybran
bomber but lack stealth.

Somehow it do 2502 dmg what is 2 more as should, and i realy dont know
why and how to fix it.