### PR TITLE
T2 mml adding silo category

### DIFF
--- a/units/INU2003/INU2003_unit.bp
+++ b/units/INU2003/INU2003_unit.bp
@@ -62,6 +62,7 @@ UnitBlueprint {
         'LAND',
         'TECH2',
         'INDIRECTFIRE',
+        'SILO',
         'ARTILLERY',
         'VISIBLETORECON',
         'RECLAIMABLE',


### PR DESCRIPTION
#189

To be restricted as other mmls in unit manager.

There is also artilery category, that other mmls dont have but its
probably for artilery suport ability.