### PR TITLE
Fix units name notes in blue print

### DIFF
--- a/units/INA0001/INA0001_unit.bp
+++ b/units/INA0001/INA0001_unit.bp
@@ -1,3 +1,5 @@
+-- Drop ship
+
 UnitBlueprint {
     Audio = {
         Open = Sound {

--- a/units/INA1001/INA1001_script.lua
+++ b/units/INA1001/INA1001_script.lua
@@ -1,4 +1,4 @@
--- t1 air scout
+-- T1 Air scout
 
 local NAirUnit = import('/lua/nomadsunits.lua').NAirUnit
 local SupportingArtilleryAbility = import('/lua/nomadsutils.lua').SupportingArtilleryAbility

--- a/units/INA1001/INA1001_unit.bp
+++ b/units/INA1001/INA1001_unit.bp
@@ -1,9 +1,11 @@
+-- T1 air scout
+
 UnitBlueprint {
     Abilities = {
         ArtillerySupport = {
             LockoutDuration = 1,
             MaxSimultaniousArtillerySupport = -1,
-            Range = 18,
+            Range = 20,
             SupportGroundTargetting = true,
             TargetCategory = 'ALLUNITS',
         },

--- a/units/INA1002/INA1002_unit.bp
+++ b/units/INA1002/INA1002_unit.bp
@@ -1,3 +1,5 @@
+-- T1 interceptor
+
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,

--- a/units/INA1003/INA1003_unit.bp
+++ b/units/INA1003/INA1003_unit.bp
@@ -1,3 +1,5 @@
+-- T1 bomber
+
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 120,

--- a/units/INA1005/INA1005_unit.bp
+++ b/units/INA1005/INA1005_unit.bp
@@ -1,4 +1,4 @@
---T1 Transport
+-- T1 Transport
 
 UnitBlueprint {
     AI = {

--- a/units/INA2001/INA2001_unit.bp
+++ b/units/INA2001/INA2001_unit.bp
@@ -1,3 +1,5 @@
+-- T2 transport
+
 UnitBlueprint {
     AI = {
         BeaconName = 'UEB5102',

--- a/units/INA2002/INA2002_unit.bp
+++ b/units/INA2002/INA2002_unit.bp
@@ -1,3 +1,5 @@
+-- T2 fighter/bomber
+
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 100,

--- a/units/INA2003/INA2003_unit.bp
+++ b/units/INA2003/INA2003_unit.bp
@@ -1,3 +1,5 @@
+-- T2 torpedo gunship
+
 UnitBlueprint {
     Abilities = {
         ArtillerySupport = {

--- a/units/INA3001/INA3001_unit.bp
+++ b/units/INA3001/INA3001_unit.bp
@@ -1,3 +1,5 @@
+-- T3 spy plane
+
 UnitBlueprint {
     Air = {
         AutoLandTime = 1,

--- a/units/INA3003/INA3003_unit.bp
+++ b/units/INA3003/INA3003_unit.bp
@@ -1,3 +1,5 @@
+-- ASF 
+
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,

--- a/units/INA3006/INA3006_unit.bp
+++ b/units/INA3006/INA3006_unit.bp
@@ -1,3 +1,5 @@
+-- T3 gunship Hornet
+
 UnitBlueprint {
     Abilities = {
         ArtillerySupport = {
@@ -539,7 +541,7 @@ UnitBlueprint {
             FiringRandomness = 0,
             FiringTolerance = 180,
             Label = 'AAMissile',
-            MinRadius = 3,
+            MinRadius = 0,
             MaxRadius = 40,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 2,

--- a/units/INA4001/INA4001_unit.bp
+++ b/units/INA4001/INA4001_unit.bp
@@ -1,3 +1,5 @@
+-- T4 experimental transport Comet
+
 UnitBlueprint {
     Abilities = {
         ArtillerySupport = {

--- a/units/INB0101/INB0101_unit.bp
+++ b/units/INB0101/INB0101_unit.bp
@@ -1,4 +1,4 @@
---T1 Land Factory
+-- T1 Land Factory
 
 UnitBlueprint {
     AI = {

--- a/units/INB0201/INB0201_unit.bp
+++ b/units/INB0201/INB0201_unit.bp
@@ -1,4 +1,4 @@
---T2 Land Factory HQ
+-- T2 Land Factory HQ
 
 UnitBlueprint {
     AI = {

--- a/units/INB0202/INB0202_unit.bp
+++ b/units/INB0202/INB0202_unit.bp
@@ -1,4 +1,4 @@
---T2 Air Factory
+-- T2 Air Factory
 
 UnitBlueprint {
     AI = {

--- a/units/INB0203/INB0203_unit.bp
+++ b/units/INB0203/INB0203_unit.bp
@@ -1,4 +1,4 @@
---T2 Naval Factory HQ
+-- T2 Naval Factory HQ
 
 UnitBlueprint { 
     AI = {

--- a/units/INB0211/INB0211_unit.bp
+++ b/units/INB0211/INB0211_unit.bp
@@ -1,4 +1,4 @@
---T2 Land Factory Support
+-- T2 Land Factory Support
 
 UnitBlueprint {
     AI = {

--- a/units/INB0213/INB0213_unit.bp
+++ b/units/INB0213/INB0213_unit.bp
@@ -1,4 +1,4 @@
---T2 naval factory support
+-- T2 naval factory support
 
 UnitBlueprint {
     AI = {

--- a/units/INB0301/INB0301_unit.bp
+++ b/units/INB0301/INB0301_unit.bp
@@ -1,4 +1,4 @@
---T3 Land Factory HQ
+-- T3 Land Factory HQ
 
 UnitBlueprint {
     AI = {

--- a/units/INB0302/INB0302_unit.bp
+++ b/units/INB0302/INB0302_unit.bp
@@ -1,4 +1,4 @@
---T3 Air Factory HQ
+-- T3 Air Factory HQ
 
 UnitBlueprint {
     AI = {

--- a/units/INB0303/INB0303_unit.bp
+++ b/units/INB0303/INB0303_unit.bp
@@ -1,4 +1,4 @@
---T3 Naval Factory HQ
+-- T3 Naval Factory HQ
 
 UnitBlueprint {
     AI = {

--- a/units/INB0304/INB0304_unit.bp
+++ b/units/INB0304/INB0304_unit.bp
@@ -1,4 +1,4 @@
--- SACU FActory
+-- SACU Factory
 
 UnitBlueprint {
     AI = {

--- a/units/INB0311/INB0311_unit.bp
+++ b/units/INB0311/INB0311_unit.bp
@@ -1,4 +1,4 @@
---T3 Land Factory support
+-- T3 Land Factory support
 
 UnitBlueprint {
     AI = {

--- a/units/INB0312/INB0312_unit.bp
+++ b/units/INB0312/INB0312_unit.bp
@@ -1,4 +1,4 @@
---T3 Air Factory support
+-- T3 Air Factory support
 
 UnitBlueprint {
     AI = {

--- a/units/INB0313/INB0313_unit.bp
+++ b/units/INB0313/INB0313_unit.bp
@@ -1,4 +1,4 @@
---T3 naval factory support
+-- T3 naval factory support
 
 UnitBlueprint {
     AI = {

--- a/units/INB1101/INB1101_unit.bp
+++ b/units/INB1101/INB1101_unit.bp
@@ -1,4 +1,4 @@
---T1 Pgen
+-- T1 Pgen
 
 UnitBlueprint {
     Adjacency = 'T1PowerGeneratorAdjacencyBuffs',

--- a/units/INB1103/INB1103_unit.bp
+++ b/units/INB1103/INB1103_unit.bp
@@ -1,4 +1,4 @@
--- T2 mass fab
+-- T2 mass fabricator
 
 UnitBlueprint {
     Adjacency = 'T1MassFabricatorAdjacencyBuffs',

--- a/units/INB1106/INB1106_unit.bp
+++ b/units/INB1106/INB1106_unit.bp
@@ -1,4 +1,4 @@
---Mass storage
+-- Mass storage
 
 UnitBlueprint {
     Adjacency = 'T1MassStorageAdjacencyBuffs',

--- a/units/INB1107/INB1107_unit.bp
+++ b/units/INB1107/INB1107_unit.bp
@@ -1,4 +1,4 @@
---Hydrocarbon power plant
+-- Hydrocarbon power plant
 
 UnitBlueprint {
     Adjacency = 'HydrocarbonAdjacencyBuffs',

--- a/units/INB1302/INB1302_unit.bp
+++ b/units/INB1302/INB1302_unit.bp
@@ -1,4 +1,4 @@
---T3 mex
+-- T3 mex
 
 UnitBlueprint {
     Adjacency = 'T3MassExtractorAdjacencyBuffs',

--- a/units/INB1303/INB1303_unit.bp
+++ b/units/INB1303/INB1303_unit.bp
@@ -1,4 +1,4 @@
--- T3 mass fab
+-- T3 mass fabricator
 
 UnitBlueprint {
     Adjacency = 'T3MassFabricatorAdjacencyBuffs',

--- a/units/INB2101/INB2101_unit.bp
+++ b/units/INB2101/INB2101_unit.bp
@@ -1,3 +1,5 @@
+-- T1 PD
+
 UnitBlueprint {
     Audio = {
         Destroyed = Sound {

--- a/units/INB2109/INB2109_unit.bp
+++ b/units/INB2109/INB2109_unit.bp
@@ -1,3 +1,5 @@
+-- T1 Torpedo launcher
+
 UnitBlueprint {
     AI = {
         TargetBones = {

--- a/units/INB2201/INB2201_unit.bp
+++ b/units/INB2201/INB2201_unit.bp
@@ -1,4 +1,4 @@
--- T2 point defense
+-- T2 Point defense
 
 UnitBlueprint {
     AI = {

--- a/units/INB2208/INB2208_unit.bp
+++ b/units/INB2208/INB2208_unit.bp
@@ -1,3 +1,5 @@
+-- Tactical missile launcher
+
 UnitBlueprint {
     AI = {
         InitialAutoMode = true,

--- a/units/INB3101/INB3101_unit.bp
+++ b/units/INB3101/INB3101_unit.bp
@@ -1,3 +1,5 @@
+-- T1 radar
+
 UnitBlueprint {
     Audio = {
         Destroyed = Sound {

--- a/units/INB3102/INB3102_unit.bp
+++ b/units/INB3102/INB3102_unit.bp
@@ -1,3 +1,5 @@
+-- T1 sonar
+
 UnitBlueprint {
     Audio = {
         Destroyed = Sound {

--- a/units/INB3202/INB3202_unit.bp
+++ b/units/INB3202/INB3202_unit.bp
@@ -1,4 +1,4 @@
--- t2 sonar
+-- T2 sonar
 
 UnitBlueprint {
     Audio = {

--- a/units/INB4204/INB4204_unit.bp
+++ b/units/INB4204/INB4204_unit.bp
@@ -1,3 +1,5 @@
+-- TMD
+
 UnitBlueprint {
     Audio = {
         Destroyed = Sound {

--- a/units/INB5101/INB5101_unit.bp
+++ b/units/INB5101/INB5101_unit.bp
@@ -1,4 +1,4 @@
---Wall
+-- Wall
 
 UnitBlueprint {
     Audio = {

--- a/units/INS1001/INS1001_unit.bp
+++ b/units/INS1001/INS1001_unit.bp
@@ -1,4 +1,4 @@
--- T1 sub
+-- T1 submarine
 
 UnitBlueprint {
     AI = {

--- a/units/INS1002/INS1002_unit.bp
+++ b/units/INS1002/INS1002_unit.bp
@@ -1,4 +1,4 @@
--- frigate
+-- T1 Frigate
 
 UnitBlueprint {
     Audio = {

--- a/units/INS2001/INS2001_unit.bp
+++ b/units/INS2001/INS2001_unit.bp
@@ -1,4 +1,4 @@
--- destroyer
+-- T2 Destroyer
 
 UnitBlueprint {
     AI = {

--- a/units/INS2002/INS2002_unit.bp
+++ b/units/INS2002/INS2002_unit.bp
@@ -1,4 +1,4 @@
--- Cruiser
+-- T2 Cruiser
 
 UnitBlueprint {
     AI = {

--- a/units/INS2003/INS2003_unit.bp
+++ b/units/INS2003/INS2003_unit.bp
@@ -1,4 +1,4 @@
--- rail gun boat
+-- T2 Rail gun boat
 
 UnitBlueprint {
     AI = {

--- a/units/INS3002/INS3002_unit.bp
+++ b/units/INS3002/INS3002_unit.bp
@@ -1,4 +1,4 @@
--- Tactical Sub
+-- T3 Tactical Sub
 
 UnitBlueprint {
     Audio = {

--- a/units/INS3003/INS3003_unit.bp
+++ b/units/INS3003/INS3003_unit.bp
@@ -1,4 +1,4 @@
--- Aircraft carrier
+-- T3 Aircraft carrier
 
 UnitBlueprint {
     AI = {

--- a/units/INS3004/INS3004_unit.bp
+++ b/units/INS3004/INS3004_unit.bp
@@ -1,4 +1,4 @@
--- T3 heavy destroyer
+-- T3 Heavy destroyer
 
 UnitBlueprint {
     AI = {

--- a/units/INU0001/INU0001_unit.bp
+++ b/units/INU0001/INU0001_unit.bp
@@ -1,3 +1,5 @@
+-- ACU
+
 UnitBlueprint {
     Abilities = {
         Capacitor = {

--- a/units/INU0301/INU0301_unit.bp
+++ b/units/INU0301/INU0301_unit.bp
@@ -1,3 +1,5 @@
+-- Sacu
+
 UnitBlueprint {
     Abilities = {
         Capacitor = {

--- a/units/INU1001/INU1001_unit.bp
+++ b/units/INU1001/INU1001_unit.bp
@@ -1,4 +1,4 @@
---T1 Enginer
+-- T1 Enginer
 
 UnitBlueprint {
     AI = {

--- a/units/INU1002/INU1002_unit.bp
+++ b/units/INU1002/INU1002_unit.bp
@@ -1,3 +1,5 @@
+-- T1 land scout
+
 UnitBlueprint {
     Abilities = {
         Anchor = {

--- a/units/INU1004/INU1004_unit.bp
+++ b/units/INU1004/INU1004_unit.bp
@@ -1,4 +1,4 @@
--- T1 tank bandit
+-- T1 tank Bandit
 
 UnitBlueprint {
     Audio = {

--- a/units/INU1005/INU1005_unit.bp
+++ b/units/INU1005/INU1005_unit.bp
@@ -1,3 +1,5 @@
+-- T2 Enginer
+
 UnitBlueprint {
     AI = {
         TargetBones = {

--- a/units/INU1006/INU1006_unit.bp
+++ b/units/INU1006/INU1006_unit.bp
@@ -1,4 +1,4 @@
--- t1 AA/Artilery
+-- T1 AA/Artilery
 
 UnitBlueprint {
     AI = {

--- a/units/INU1007/INU1007_unit.bp
+++ b/units/INU1007/INU1007_unit.bp
@@ -1,4 +1,4 @@
---T1 lab 
+-- T1 lab 
 
 UnitBlueprint {
     Audio = {

--- a/units/INU1008/INU1008_unit.bp
+++ b/units/INU1008/INU1008_unit.bp
@@ -1,4 +1,4 @@
--- tank destroyer
+-- Tank destroyer
 
 UnitBlueprint {
     Abilities = {

--- a/units/INU2001/INU2001_unit.bp
+++ b/units/INU2001/INU2001_unit.bp
@@ -1,3 +1,5 @@
+-- T3 Engineer
+
 UnitBlueprint {
     Audio = {
         AmbientIdle = Sound {

--- a/units/INU2002/INU2002_unit.bp
+++ b/units/INU2002/INU2002_unit.bp
@@ -1,4 +1,4 @@
---T2 hover tank
+-- T2 hover tank
 
 UnitBlueprint {
     Audio = {

--- a/units/INU2003/INU2003_unit.bp
+++ b/units/INU2003/INU2003_unit.bp
@@ -1,4 +1,4 @@
---T2 mml Avalanche
+-- T2 mml Avalanche
 
 UnitBlueprint {
     Abilities = {

--- a/units/INU2004/INU2004_unit.bp
+++ b/units/INU2004/INU2004_unit.bp
@@ -1,4 +1,4 @@
---T2 AA flak
+-- T2 mAA flak
 
 UnitBlueprint {
     Audio = {

--- a/units/INU2005/INU2005_Script.lua
+++ b/units/INU2005/INU2005_Script.lua
@@ -1,4 +1,4 @@
--- T2 main tank
+-- T2 tank Brute
 
 local NomadsEffectTemplate = import('/lua/nomadseffecttemplate.lua')
 local NLandUnit = import('/lua/nomadsunits.lua').NLandUnit

--- a/units/INU2005/INU2005_unit.bp
+++ b/units/INU2005/INU2005_unit.bp
@@ -1,4 +1,4 @@
---T2 tank Brute
+-- T2 tank Brute
 
 UnitBlueprint {
     AI = {

--- a/units/INU2007/INU2007_unit.bp
+++ b/units/INU2007/INU2007_unit.bp
@@ -1,4 +1,4 @@
---T4 beamer
+-- T4 Beamer
 
 UnitBlueprint {
     Audio = {

--- a/units/INU3003/INU3003_unit.bp
+++ b/units/INU3003/INU3003_unit.bp
@@ -1,4 +1,4 @@
---T2 EMP tank
+-- T2 EMP tank
 
 UnitBlueprint {
     AI = {

--- a/units/INU4001/INU4001_unit.bp
+++ b/units/INU4001/INU4001_unit.bp
@@ -1,3 +1,5 @@
+-- T4 missile tank
+
 UnitBlueprint {
     Abilities = {
         BombardMode = {

--- a/units/INU4002/INU4002_unit.bp
+++ b/units/INU4002/INU4002_unit.bp
@@ -1,4 +1,4 @@
--- Bullfrog
+-- T4 Bullfrog experimental
 
 UnitBlueprint {
     AI = {


### PR DESCRIPTION
This is cosmetic comit that corect all notes in start with units name,
to not need search for them in code.

Ill go for all units, and get it into same standards.