### PR TITLE
Anchor buff / balance units with anchor

### DIFF
--- a/loc/US/nomads_strings_core.lua
+++ b/loc/US/nomads_strings_core.lua
@@ -68,7 +68,7 @@ tooltip_lobby_unit_restriction_nonomads_desc = ""
 tooltip_radar_boost_title = "Radar Boost Toggle"
 tooltip_radar_boost_desc = "Starts/stops charging radar boosting for the selection units. When finished charging up radar boost initiates automatically. Charging up requires energy."
 tooltip_bombardmode_title = "Bombard Mode Toggle"
-tooltip_bombardmode_desc = "Turn the selection units bombard mode on/off"
+tooltip_bombardmode_desc = "bombard mode decrese reload time by 50% but increse firing randomnes"
 tooltip_no_air_title = "Anti-Air Toggle"
 tooltip_no_air_desc ="Turn the selection units anti-air attack on/off"
 tooltip_snipermode_title = "Sniper Mode Toggle"
@@ -76,7 +76,7 @@ tooltip_snipermode_desc = "Turn sniper mode on/off"
 tooltip_usecapacitor_title = "Capacitor Toggle"
 tooltip_usecapacitor_desc = "Boost unit temporarily (firepower, build power, regeneration) using the capacitor ability"
 tooltip_anchor_title = "Anchor Toggle"
-tooltip_anchor_desc = "Immobilizes the unit"
+tooltip_anchor_desc = "Immobilizes the unit and increse weapon range, vision, radar and build rate by 30%"
 tooltip_stealthshield_title = "Stealth Shield Toggle"
 tooltip_stealthshield_desc = "Turn the select units shield and stealth field on/off"
 
@@ -499,7 +499,7 @@ inu2004_name = "Skyshell"
 
 -- T2 heavy tank
 inu2005_desc = "Heavy Tank"
-inu2005_help = "Heavy tank, good armor and powerful weapons."
+inu2005_help = "Heavy tank, powerful weapons with anchor option for defensive use."
 inu2005_name = "Brute"
 
 -- T2 assault bot
@@ -686,14 +686,14 @@ inu3007_desc = "Mobile Anti-Air Missile Launcher"
 inu3007_help = "Launches anti-air missiles at enemy aircraft."
 inu3007_name = "Watchman"
 
--- T3 mobile missile defense
+-- T2 mobile missile defense
 inu3008_desc = "Field Engineer"
-inu3008_help = "Hover unit equipped with limited engineering capabilities and a tactical missile defense installation. Can only construct offensive and defensive structures."
+inu3008_help = "Hover unit equipped with engineering capabilities and a tactical missile defense installation. Have anchor option for higer intel and build capacity."
 inu3008_name = "Scarab"
 
 -- T3 tracked tank
 inu3009_desc = "Armored Assault Tank"
-inu3009_help = "Tracked tank unit that carries dual plasma cannons and very heavy armor."
+inu3009_help = "Tank that carries dual cannons and heavy armor. Have anchor option for defensive use."
 inu3009_name = "Slugger"
 
 

--- a/loc/US/nomads_strings_core.lua
+++ b/loc/US/nomads_strings_core.lua
@@ -68,7 +68,7 @@ tooltip_lobby_unit_restriction_nonomads_desc = ""
 tooltip_radar_boost_title = "Radar Boost Toggle"
 tooltip_radar_boost_desc = "Starts/stops charging radar boosting for the selection units. When finished charging up radar boost initiates automatically. Charging up requires energy."
 tooltip_bombardmode_title = "Bombard Mode Toggle"
-tooltip_bombardmode_desc = "bombard mode decrese reload time by 50% but increse firing randomnes"
+tooltip_bombardmode_desc = "Bombardment mode decreases the reload time by 50% but increases the fireing randomness."
 tooltip_no_air_title = "Anti-Air Toggle"
 tooltip_no_air_desc ="Turn the selection units anti-air attack on/off"
 tooltip_snipermode_title = "Sniper Mode Toggle"
@@ -76,7 +76,7 @@ tooltip_snipermode_desc = "Turn sniper mode on/off"
 tooltip_usecapacitor_title = "Capacitor Toggle"
 tooltip_usecapacitor_desc = "Boost unit temporarily (firepower, build power, regeneration) using the capacitor ability"
 tooltip_anchor_title = "Anchor Toggle"
-tooltip_anchor_desc = "Immobilizes the unit and increse weapon range, vision, radar and build rate by 30%"
+tooltip_anchor_desc = "Immobilizes the unit and increases weapon range, vision, radar and build rate by 30%."
 tooltip_stealthshield_title = "Stealth Shield Toggle"
 tooltip_stealthshield_desc = "Turn the select units shield and stealth field on/off"
 
@@ -688,12 +688,12 @@ inu3007_name = "Watchman"
 
 -- T2 mobile missile defense
 inu3008_desc = "Field Engineer"
-inu3008_help = "Hover unit equipped with engineering capabilities and a tactical missile defense installation. Have anchor option for higer intel and build capacity."
+inu3008_help = "Hover unit equipped with engineering capabilities and a tactical missile defense installation. Has anchor option to increase intel and tmd range as well as the build capacity."
 inu3008_name = "Scarab"
 
 -- T3 tracked tank
 inu3009_desc = "Armored Assault Tank"
-inu3009_help = "Tank that carries dual cannons and heavy armor. Have anchor option for defensive use."
+inu3009_help = "Tank that carries dual cannons and heavy armor. Has anchor option for defensive use."
 inu3009_name = "Slugger"
 
 

--- a/lua/nomadsbuffs.lua
+++ b/lua/nomadsbuffs.lua
@@ -22,16 +22,16 @@ BuffBlueprint {
             DeactivateDelay = 1.5,
         },
         MaxRadius = {
-            Mult = 1.15,
+            Mult = 1.3,
         },
         RadarRadius = {
-            Mult = 1.15,
+            Mult = 1.3,
         },
         BuildRate = {
             Mult = 1.3,
         },
         VisionRadius = {
-            Mult = 1.15,
+            Mult = 1.3,
         },
     },
 }

--- a/projectiles/NParticleBlast1/NParticleBlast1_proj.bp
+++ b/projectiles/NParticleBlast1/NParticleBlast1_proj.bp
@@ -36,6 +36,6 @@ ProjectileBlueprint {
         DestroyOnWater = false,
         InitialSpeed = 35,
         VelocityAlign = true,
-        UseGravity = false, -- should make unit not get stuck shooting AA
+        UseGravity = true, -- should make unit not get stuck shooting AA
     },
 }

--- a/units/INU1002/INU1002_Script.lua
+++ b/units/INU1002/INU1002_Script.lua
@@ -4,9 +4,8 @@ local AddAnchorAbilty = import('/lua/nomadsutils.lua').AddAnchorAbilty
 local NHoverLandUnit = import('/lua/nomadsunits.lua').NHoverLandUnit
 local DarkMatterWeapon1 = import('/lua/nomadsweapons.lua').DarkMatterWeapon1
 local SlowHover = import('/lua/defaultunits.lua').SlowHoverLandUnit
-local SupportingArtilleryAbility = import('/lua/nomadsutils.lua').SupportingArtilleryAbility
 
-NHoverLandUnit = SupportingArtilleryAbility(AddAnchorAbilty(NHoverLandUnit))
+NHoverLandUnit = AddAnchorAbilty(NHoverLandUnit)
 
 INU1002 = Class(NHoverLandUnit, SlowHover) {
     Weapons = {

--- a/units/INU1002/INU1002_unit.bp
+++ b/units/INU1002/INU1002_unit.bp
@@ -1,14 +1,9 @@
+-- T1 land scout
+
 UnitBlueprint {
     Abilities = {
         Anchor = {
             Buff = 'AnchorModeImmobilizeAddRange',
-        },
-        ArtillerySupport = {
-            LockoutDuration = 1,
-            MaxSimultaniousArtillerySupport = -1,
-            Range = 18,
-            SupportGroundTargetting = true,
-            TargetCategory = 'ALLUNITS',
         },
     },
     Audio = {
@@ -52,11 +47,6 @@ UnitBlueprint {
             Cue = 'Nomads_Select_Vehicle',
             LodCutoff = 'UnitMove_LodCutoff',
         },
-        SupportingArtilleryPing = Sound {
-            Bank = 'NomadsMisc',
-            Cue = 'ArtillerySupportPinger',
-            LodCutoff = 'UnitMove_LodCutoff',
-        },
     },
     Buffs = {
         Regen = {
@@ -86,7 +76,6 @@ UnitBlueprint {
         'HOVER',
         'OVERLAYDIRECTFIRE',
         'OVERLAYRADAR',
-        'ARTILLERYSUPPORT',
     },
     CollisionOffsetZ = -0.02,
     Defense = {
@@ -102,10 +91,9 @@ UnitBlueprint {
     Description = '<LOC inu1002_desc>Land Scout',
     Display = {
         Abilities = {
+            '<LOC ability_anchor>Anchor',        
             '<LOC ability_hover>Hover',
             '<LOC ability_radar>Radar',
-            '<LOC ability_anchor>Anchor',
-            '<LOC ability_artillerysupport>Artillery Support',
         },
         BuildEffect = {
             ExtendsFront = 0.1,
@@ -240,8 +228,8 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarRadius = 45,
-        VisionRadius = 24,
+        RadarRadius = 40,   --52 with anchor
+        VisionRadius = 24,  --31,2 with anchor
     },
     Interface = {
         HelpText = '<LOC inu1002_help>Land Scout',
@@ -321,7 +309,7 @@ UnitBlueprint {
             },
             FiringTolerance = 2,
             Label = 'MainGun',
-            MaxRadius = 8,
+            MaxRadius = 23,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 35,

--- a/units/INU1008/INU1008_unit.bp
+++ b/units/INU1008/INU1008_unit.bp
@@ -1,4 +1,4 @@
--- tank destroyer
+-- Tank destroyer
 
 UnitBlueprint {
     Abilities = {
@@ -70,9 +70,8 @@ UnitBlueprint {
     Description = '<LOC inu1008_desc>Tank Destroyer',
     Display = {
         Abilities = {
-            '<LOC ability_accuratewhenstill>Accurate weapon when still',
+            '<LOC ability_anchor>Anchor',
             '<LOC ability_inaccuratewhenmoving>Inaccurate weapon when moving',
-            '<LOC ability_anchor>Anchor'
         },
         Mesh = {
             IconFadeInZoom = 130,
@@ -218,7 +217,7 @@ UnitBlueprint {
             CollideFriendly = false,
             Damage = 300,
             DamageFriendly = false,
-            DamageRadius = 1.5,
+            DamageRadius = 1,
             DamageType = 'Normal',
             DisplayName = 'Kinetic cannon',
             FireTargetLayerCapsTable = {
@@ -230,7 +229,7 @@ UnitBlueprint {
             FiringTolerance = 0,
             FiringToleranceWhileMoving = 0.5,
             Label = 'MainGun',
-            MaxRadius = 26,     --30r with anchor
+            MaxRadius = 23,     --30r with anchor
             MinRadius = 5,
             MuzzleChargeDelay = 0.5,
             MuzzleSalvoDelay = 0,

--- a/units/INU2003/INU2003_Script.lua
+++ b/units/INU2003/INU2003_Script.lua
@@ -1,7 +1,7 @@
 -- T2 missile launcher
 
+local AddBombardModeToUnit = import('/lua/nomadsutils.lua').AddBombardModeToUnit
 local Buff = import('/lua/sim/buff.lua')
-local AddAnchorAbilty = import('/lua/nomadsutils.lua').AddAnchorAbilty
 local SupportedArtilleryWeapon = import('/lua/nomadsutils.lua').SupportedArtilleryWeapon
 local NAmphibiousUnit = import('/lua/nomadsunits.lua').NAmphibiousUnit
 local TacticalMissileWeapon1 = import('/lua/nomadsweapons.lua').TacticalMissileWeapon1
@@ -9,8 +9,9 @@ local NomadsEffectTemplate = import('/lua/nomadseffecttemplate.lua')
 local EffectUtilities = import('/lua/EffectUtilities.lua')
 local SlowHover = import('/lua/defaultunits.lua').SlowHoverLandUnit
 
-NAmphibiousUnit = AddAnchorAbilty(NAmphibiousUnit)
 TacticalMissileWeapon1 = SupportedArtilleryWeapon( TacticalMissileWeapon1 )
+
+NAmphibiousUnit = AddBombardModeToUnit(NAmphibiousUnit)
 
 INU2003 = Class(NAmphibiousUnit, SlowHover) {
     Weapons = {
@@ -76,13 +77,25 @@ INU2003 = Class(NAmphibiousUnit, SlowHover) {
         return NAmphibiousUnit.OnLand(self)
     end,
 
-    EnableSpecialToggle = function(self)
-        self:EnableAnchor(self)
+        SetBombardmentMode = function(self, enable, changedByTransport)
+        NAmphibiousUnit.SetBombardmentMode(self, enable, changedByTransport)
+        self:SetScriptBit('RULEUTC_WeaponToggle', enable)
     end,
 
-    DisableSpecialToggle = function(self)
-        self:DisableAnchor(self)
+    OnScriptBitSet = function(self, bit)
+        NAmphibiousUnit.OnScriptBitSet(self, bit)
+        if bit == 1 then 
+            self.SetBombardmentMode(self, true, false)
+        end
     end,
+
+    OnScriptBitClear = function(self, bit)
+        NAmphibiousUnit.OnScriptBitClear(self, bit)
+        if bit == 1 then 
+            self.SetBombardmentMode(self, false, false)
+        end
+    end,
+    
 }
 
 TypeClass = INU2003

--- a/units/INU2003/INU2003_unit.bp
+++ b/units/INU2003/INU2003_unit.bp
@@ -65,6 +65,7 @@ UnitBlueprint {
         'VISIBLETORECON',
         'RECLAIMABLE',
         'OVERLAYINDIRECTFIRE',
+        'SILO',
     },
     Defense = {
         AirThreatLevel = 0,

--- a/units/INU2003/INU2003_unit.bp
+++ b/units/INU2003/INU2003_unit.bp
@@ -1,10 +1,9 @@
---T2 mml Avalanche
+-- T2 mml Avalanche
 
 UnitBlueprint {
-    Abilities = {
-        Anchor = {
-            Buff = 'AnchorModeImmobilizeAddRange',
-        },
+    AI = {
+        BombardModeCheckRadius = 8,
+        BombardModeCheckUnits = 4,
     },
     Audio = {
         AmbientMove = Sound {
@@ -62,7 +61,6 @@ UnitBlueprint {
         'LAND',
         'TECH2',
         'INDIRECTFIRE',
-        'SILO',
         'ARTILLERY',
         'VISIBLETORECON',
         'RECLAIMABLE',
@@ -83,8 +81,8 @@ UnitBlueprint {
         Abilities = {
             '<LOC ability_amphibious>Amphibious',
             '<LOC ability_submergedsurfaceattack>Attacks from under water',
+            '<LOC ability_bombardarea>Area bombardment',
             '<LOC ability_supportedartillerygun>Supported Artillery Gun',
-            '<LOC ability_anchor>Anchor'
         },
         BuildEffect = {
             ExtendsFront = 0.05,
@@ -165,14 +163,14 @@ UnitBlueprint {
         FactionName = 'Nomads',
         Icon = 'amph',
         OrderOverrides = {
-            RULEUTC_SpecialToggle = {
-                bitmapId = 'toggle-anchor',
-                helpText = 'toggle_anchor',
+            RULEUTC_WeaponToggle = {
+                bitmapId = 'toggle-bombardmode',
+                helpText = 'toggle_bombardmode',
             },
         },
         TechLevel = 'RULEUTL_Advanced',
         ToggleCaps = {
-            RULEUTC_SpecialToggle = true,
+            RULEUTC_WeaponToggle = true,
         },
         UnitName = '<LOC inu2003_name>Avalanche',
         UnitWeight = 1,
@@ -243,6 +241,10 @@ UnitBlueprint {
                 },
             },
             BallisticArc = 'RULEUBA_HighArc',
+            
+            BombardParticipant = true,
+            BombardSwingTurret = false,
+            
             CollideFriendly = false,
             Damage = 200,
             DamageFriendly = false,
@@ -255,8 +257,8 @@ UnitBlueprint {
                 Seabed = 'Land|Water',
                 Sub = 'Land|Water',
             },
-            FiringRandomness = 0.9,
-            FiringRandomnessWhileMoving = 1.1,
+            FiringRandomness = 0.5,
+            FiringRandomnessWhileMoving = 1,
             FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 60,

--- a/units/INU2005/INU2005_Script.lua
+++ b/units/INU2005/INU2005_Script.lua
@@ -1,8 +1,12 @@
 -- T2 main tank
 
+local AddAnchorAbilty = import('/lua/nomadsutils.lua').AddAnchorAbilty
 local NomadsEffectTemplate = import('/lua/nomadseffecttemplate.lua')
 local NLandUnit = import('/lua/nomadsunits.lua').NLandUnit
 local ParticleBlaster1 = import('/lua/nomadsweapons.lua').ParticleBlaster1
+
+NLandUnit = AddAnchorAbilty(NLandUnit)
+
 
 INU2005 = Class(NLandUnit) {
     Weapons = {
@@ -35,6 +39,14 @@ INU2005 = Class(NLandUnit) {
             emit = CreateAttachedEmitter(self, bone, army, v)
             self.Trash:Add(emit)
         end
+    end,
+    
+    EnableSpecialToggle = function(self)
+        self:EnableAnchor(self)
+    end,
+
+    DisableSpecialToggle = function(self)
+        self:DisableAnchor(self)
     end,
 }
 

--- a/units/INU2005/INU2005_unit.bp
+++ b/units/INU2005/INU2005_unit.bp
@@ -1,6 +1,11 @@
---T2 tank Brute
+-- T2 tank Brute
 
 UnitBlueprint {
+    Abilities = {
+        Anchor = {
+            Buff = 'AnchorModeImmobilizeAddRange',
+        },
+    },
     AI = {
         TargetBones = {
             'Turret',
@@ -61,14 +66,17 @@ UnitBlueprint {
         AirThreatLevel = 0,
         ArmorType = 'Normal',
         EconomyThreatLevel = 0,
-        Health = 1250,
-        MaxHealth = 1250,
+        Health = 1750,
+        MaxHealth = 1750,
         RegenRate = 0,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 4,
     },
     Description = '<LOC inu2005_desc>Heavy Tank',
     Display = {
+        Abilities = {
+            '<LOC ability_anchor>Anchor',
+        },
         BuildEffect = {
             ExtendsFront = 0.15,
             ExtendsRear = 0.1,
@@ -118,9 +126,9 @@ UnitBlueprint {
         UniformScale = 0.43,
     },
     Economy = {
-        BuildCostEnergy = 990,
-        BuildCostMass = 198,
-        BuildTime = 880,
+        BuildCostEnergy = 1500,
+        BuildCostMass = 297,
+        BuildTime = 1320,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,
@@ -144,7 +152,16 @@ UnitBlueprint {
         },
         FactionName = 'Nomads',
         Icon = 'land',
+        OrderOverrides = {
+            RULEUTC_SpecialToggle = {
+                bitmapId = 'toggle-anchor',
+                helpText = 'toggle_anchor',
+            },
+        },
         TechLevel = 'RULEUTL_Advanced',
+        ToggleCaps = {
+            RULEUTC_SpecialToggle = true,
+        },
         UnitName = '<LOC inu2005_name>Brute',
         UnitWeight = 1,
     },
@@ -168,11 +185,11 @@ UnitBlueprint {
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        MaxAcceleration = 3.2,
-        MaxBrake = 3.2,
-        MaxSpeed = 3.2,
+        MaxAcceleration = 2.8,
+        MaxBrake = 2.8,
+        MaxSpeed = 2.8,
         MaxSpeedReverse = 0,
-        MaxSteerForce = 3.2,
+        MaxSteerForce = 2.8,
         MeshExtentsX = 0.75,
         MeshExtentsY = 0.45,
         MeshExtentsZ = 1.25,
@@ -195,11 +212,11 @@ UnitBlueprint {
         TransportClass = 2,
     },
     Veteran = {
-        Level1 = 6,
-        Level2 = 12,
-        Level3 = 18,
-        Level4 = 24,
-        Level5 = 30,
+        Level1 = 8,
+        Level2 = 16,
+        Level3 = 24,
+        Level4 = 32,
+        Level5 = 40,
     },
     Weapon = {
         {
@@ -214,7 +231,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_LowArc',
             DamageFriendly = false,
             CollideFriendly = false,
-            Damage = 50,
+            Damage = 120,
             DamageType = 'Normal',
             DisplayName = 'Particle blaster',
             FireTargetLayerCapsTable = {
@@ -225,10 +242,10 @@ UnitBlueprint {
             LeadTarget = true,
             Label = 'MainGun',
             MaxRadius = 20,
-            MinRadius = 2,
+            MinRadius = 0,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 30,
+            MuzzleVelocity = 30  ,
             ProjectileId = '/projectiles/NParticleBlast1/NParticleBlast1_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 3,
@@ -260,7 +277,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 0.5,
+            RateOfFire = 0.25,
             TargetCheckInterval = 1,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
@@ -282,7 +299,7 @@ UnitBlueprint {
             TurretPitchSpeed = 60,
             TurretYaw = 0,
             TurretYawRange = 180,
-            TurretYawSpeed = 100,
+            TurretYawSpeed = 90,
             Turreted = true,
             UseFiringSolutionInsteadOfAimBone = true,
             WeaponCategory = 'Direct Fire',

--- a/units/INU3007/INU3007_unit.bp
+++ b/units/INU3007/INU3007_unit.bp
@@ -251,7 +251,7 @@ UnitBlueprint {
             FiringRandomness = 0,
             FiringTolerance = 60,
             Label = 'MainGun',
-            MaxRadius = 46,
+            MaxRadius = 44,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 45,

--- a/units/INU3008/INU3008_unit.bp
+++ b/units/INU3008/INU3008_unit.bp
@@ -97,7 +97,7 @@ UnitBlueprint {
             Level5 = 10,
         },
     },
-    BuildIconSortPriority = 120,
+    BuildIconSortPriority = 15,
     Categories = {
         'SELECTABLE',
         'BUILTBYTIER2LANDFACTORY',
@@ -239,7 +239,7 @@ UnitBlueprint {
             'BUILTBYTIER2ENGINEER DEFENSE NOMADS',
             'BUILTBYTIER2ENGINEER INDIRECTFIRE NOMADS',
         },
-        MaintenanceConsumptionPerSecondEnergy = 10,
+        MaintenanceConsumptionPerSecondEnergy = 15,
         MaxBuildDistance = 12.5,    --from 10
         NeedToFaceTargetToBuild = false,
         TeleportEnergyMod = 0.15,
@@ -398,7 +398,7 @@ UnitBlueprint {
             FiringRandomness = 0,
             Label = 'MainGun',
             MaximumBeamLength = 40,
-            MaxRadius = 25,
+            MaxRadius = 23, --29,9 with anchor
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             NeedPrep = true,

--- a/units/INU3009/INU3009_Script.lua
+++ b/units/INU3009/INU3009_Script.lua
@@ -1,12 +1,23 @@
 -- T3 tank
 
+local AddAnchorAbilty = import('/lua/nomadsutils.lua').AddAnchorAbilty
 local NLandUnit = import('/lua/nomadsunits.lua').NLandUnit
 local PlasmaCannon = import('/lua/nomadsweapons.lua').PlasmaCannon
+
+NLandUnit = AddAnchorAbilty(NLandUnit)
 
 INU3009 = Class(NLandUnit) {
     Weapons = {
         MainGun = Class(PlasmaCannon) {},
-    }
+    },
+
+    EnableSpecialToggle = function(self)
+        self:EnableAnchor(self)
+    end,
+
+    DisableSpecialToggle = function(self)
+        self:DisableAnchor(self)
+    end,
 }
 
 TypeClass = INU3009

--- a/units/INU3009/INU3009_unit.bp
+++ b/units/INU3009/INU3009_unit.bp
@@ -1,6 +1,11 @@
 -- T3 tank Slugger
 
 UnitBlueprint {
+    Abilities = {
+        Anchor = {
+            Buff = 'AnchorModeImmobilizeAddRange',
+        },
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UEL',
@@ -55,14 +60,17 @@ UnitBlueprint {
         AirThreatLevel = 0,
         ArmorType = 'Normal',
         EconomyThreatLevel = 0,
-        Health = 6400,
-        MaxHealth = 6400,
+        Health = 6500,
+        MaxHealth = 6500,
         RegenRate = 0,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 18,
     },
     Description = '<LOC inu3009_desc>Armored Assault Tank',
     Display = {
+        Abilities = {
+            '<LOC ability_anchor>Anchor',
+        },
         BuildEffect = {
             ExtendsFront = 0.1,
             ExtendsRear = 0.35,
@@ -134,7 +142,16 @@ UnitBlueprint {
         },
         FactionName = 'Nomads',
         Icon = 'land',
+        OrderOverrides = {
+            RULEUTC_SpecialToggle = {
+                bitmapId = 'toggle-anchor',
+                helpText = 'toggle_anchor',
+            },
+        },
         TechLevel = 'RULEUTL_Secret',
+        ToggleCaps = {
+            RULEUTC_SpecialToggle = true,
+        },
         UnitName = '<LOC inu3009_name>Slugger',
         UnitWeight = 1,
     },
@@ -159,11 +176,11 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         Elevation = 0,
-        MaxAcceleration = 3,
-        MaxBrake = 3,
-        MaxSpeed = 3,
-        MaxSpeedReverse = 3,
-        MaxSteerForce = 3,
+        MaxAcceleration = 2.8,
+        MaxBrake = 2.8,
+        MaxSpeed = 2.8,
+        MaxSpeedReverse = 2.8,
+        MaxSteerForce = 2.8,
         MeshExtentsX = 0.8,
         MeshExtentsY = 0.65,
         MeshExtentsZ = 1.25,
@@ -222,7 +239,7 @@ UnitBlueprint {
             MaxRadius = 28,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 45,
+            MuzzleVelocity = 35,
             NotExclusive = true,
             ProjectileId =  '/projectiles/NPlasmaProj1/NPlasmaProj1_proj.bp',
             ProjectilesPerOnFire = 1,


### PR DESCRIPTION
This comit is linked with all anchored units that also contain balance
changes while its linked together.

T1 land scout -> remove artilery support while it was ussles on unit
that die in 0second.
-- increse range that was stupidly low, and adjust radar

T2 mml Avalanche -> replace anchor with bombard mode,

T2 tank Brute -> move into 300m category, add anchor. its obsidian style
unit in lower class. change projectile to use gravity.

T2 field enginer Scarab -> decrese range of tmd to fit with buffed
anchor, change build icon proority to be near enginer, increse e
maintaince.

T3 mAA -> decrese range to better fit with buffed anchor

T3 tank Slugger -> add anchor, and balance (more hp, less speed)