### PR TITLE
cosmetic T2trans+T3gunship+ACU projetile size

### DIFF
--- a/projectiles/NAPRound1/NAPRound1_proj.bp
+++ b/projectiles/NAPRound1/NAPRound1_proj.bp
@@ -28,7 +28,7 @@ ProjectileBlueprint {
             Type = 'Small01',
         },
         MeshBlueprint = '/projectiles/CIFMolecularResonanceShell01/CIFMolecularResonanceShell01_mesh.bp',
-        StrategicIconSize = 3,
+        StrategicIconSize = 2,
         UniformScale = 0.8,
     },
     General = {

--- a/units/INA2001/INA2001_unit.bp
+++ b/units/INA2001/INA2001_unit.bp
@@ -1,3 +1,5 @@
+-- T2 transport
+
 UnitBlueprint {
     AI = {
         BeaconName = 'UEB5102',
@@ -127,44 +129,12 @@ UnitBlueprint {
             '<LOC ability_transport>Transport',
             '<LOC ability_flares>Flares',
         },
---        AnimationLand = '/units/INA2001/INA2001_atakeoff01.sca',
+
         BuildEffect = {
             ExtendsFront = 0,
             ExtendsRear = 0,
         },
---        LayerChangeEffects = {
---            AirLand = {
---                Effects = {
---                    {
---                        Bones = {
---                            'Front_Right_Exhaust',
---                            'Front_Left_Exhaust',
---                            'Back_Right_Exhaust',
---                            'Back_Left_Exhaust',
---                        },
---                        Offset = {
---                            0,
---                            0,
---                            0,
---                        },
---                        Type = 'Landing01',
---                    },
---                },
---            },
---            LandAir = {
---                Effects = {
---                   {
---                        Bones = {
---                            'Front_Right_Exhaust',
---                            'Front_Left_Exhaust',
---                            'Back_Right_Exhaust',
---                            'Back_Left_Exhaust',
---                        },
---                        Type = 'TakeOff01',
---                    },
---                },
---            },
---        },
+
         Mesh = {
             IconFadeInZoom = 130,
             LODs = {
@@ -174,18 +144,6 @@ UnitBlueprint {
                 },
             },
         },
---        MovementEffects = {
---            BeamExhaust = {
---                Bones = {
---                    'Front_Right_Exhaust',
---                    'Front_Left_Exhaust',
---                    'Back_Right_Exhaust',
---                    'Back_Left_Exhaust',
---                },
---                Cruise = true,
---                Idle = true,
---            },
---        },
         PlaceholderMeshName = 'UXB0000',
         SpawnRandomRotation = false,
         UniformScale = 0.7,  -- don't play with this too much, transported units might do bumper cars when set down

--- a/units/INA3006/INA3006_unit.bp
+++ b/units/INA3006/INA3006_unit.bp
@@ -1,3 +1,5 @@
+-- T3 gunship Hornet
+
 UnitBlueprint {
     Abilities = {
         ArtillerySupport = {
@@ -539,7 +541,7 @@ UnitBlueprint {
             FiringRandomness = 0,
             FiringTolerance = 180,
             Label = 'AAMissile',
-            MinRadius = 3,
+            MinRadius = 0,
             MaxRadius = 40,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 2,


### PR DESCRIPTION
t3 gunship remove minimal range,  hornet cant fire on that range by
weapon physic, but situation where is this information actual is so rare
so i rather remove it to looks nicer.

T2 transport remove non used code

ACU decrese projectile strategic icon size