### PR TITLE
add nomadhook for air unit blackhole again

### DIFF
--- a/nomadhook/lua/defaultunits.lua
+++ b/nomadhook/lua/defaultunits.lua
@@ -1,0 +1,23 @@
+do
+
+
+local oldAirUnit = AirUnit
+
+AirUnit = Class(oldAirUnit) {
+
+    OnKilled = function(self, instigator, type, overkillRatio)
+        -- if killed by black hole then suck in unit regardless of flying or not
+        if self:DoOnKilledByBlackhole(type) then
+            self.DeathBounce = 1
+            if instigator and IsUnit(instigator) then
+                instigator:OnKilledUnit(self)
+            end
+            MobileUnit.OnKilled(self, instigator, type, overkillRatio)
+        else
+            oldAirUnit.OnKilled(self, instigator, type, overkillRatio)
+        end
+    end,
+}
+
+
+end


### PR DESCRIPTION
adds the code for sucking in air units into the blackhole again. It was
removed to fix #187 but works again with the latest version of
FAF/deploy/fafdevelop