### PR TITLE
Fixed Trees not Disappearing when Killed and "Transport Full" Sound

### DIFF
--- a/nomadhook/lua/proptree.lua
+++ b/nomadhook/lua/proptree.lua
@@ -4,9 +4,6 @@ local NomadsEffectTemplate = import('/lua/nomadseffecttemplate.lua')
 local RandomFloat = import('/lua/utilities.lua').GetRandomFloat
 local Prop = import('/lua/sim/Prop.lua').Prop
 
-local RemoveDamagedTrees = false
-
-
 -- Redone the trees quite significantly. This may be a bit destructive but else I couldn't get the trees working like I wanted.
 
 local oldTree = Tree
@@ -28,6 +25,7 @@ Tree = Class(oldTree) {
 
     OnDamage = function(self, instigator, armormod, direction, type)
         self:CheckForBlackHoleDamage(instigator, type)
+        oldTree.OnDamage(self, instigator, armormod, direction, type)
     end,
 
     OnBlackHoleSuckingIn = function(self, blackhole)
@@ -91,10 +89,13 @@ Tree = Class(oldTree) {
             self.Fallen = true
             self.Burning = false
             self:DestroyFireEffects()
-            if RemoveDamagedTrees then
-                WaitSeconds(30)
-                self:Disappear()
-            end
+
+            -- Fixes trees not disappearing.
+            WaitSeconds(30)
+            self:SinkAway(-.1)
+            self.Motor = nil
+            WaitSeconds(10)
+            self:Destroy()
         end,
 
         OnDamage = function(self, instigator, armormod, direction, type)

--- a/units/INA1005/INA1005_script.lua
+++ b/units/INA1005/INA1005_script.lua
@@ -1,15 +1,15 @@
 -- T1 transport
 
-local NAirUnit = import('/lua/nomadsunits.lua').NAirUnit
+local NAirTransportUnit = import('/lua/nomadsunits.lua').NAirTransportUnit
 
-INA1005 = Class(NAirUnit) {
+INA1005 = Class(NAirTransportUnit) {
 
     DestructionPartsLowToss = {'INA1005'},
     DestroySeconds = 7.5,
 
     OnKilled = function(self, instigator, type, overkillRatio)
         self:TransportDetachAllUnits(false)
-        NAirUnit.OnKilled(self, instigator, type, overkillRatio)
+        NAirTransportUnit.OnKilled(self, instigator, type, overkillRatio)
     end,
 }
 


### PR DESCRIPTION
Fixes: #276. Our current hook had a Boolean set to false to stop the trees from destroying themselves. Added the missing code to the FallenState of our trees to make them sink and disappear. 

Side note: This also stops them from insta-dying when the ACU Spawns (Creates more of a realistic gate-in effect).

The T1 Nomad Transport was importing the `NAirUnit` class from `nomadsunits` to its script instead of `NAirTransportUnit`. I would imagine the reason you would have to spawn another transport to get it to work is because the transport class isn't imported by the T1 Nomad Transport script when it's created. However, the class is imported when any other transport is created. Changing the import for the T1 Nomad Transport has fixed all audio errors without affecting the transport behaviour.  Tested and ready for verification. Enjoy. 

Fixes: #229 

P.S. For future reference. The "Transport Full" announcement is handled in the `aibrain.lua` file.