### PR TITLE
enh/ add minimum velocity to bomber weapons

### DIFF
--- a/units/INA1003/INA1003_Script.lua
+++ b/units/INA1003/INA1003_Script.lua
@@ -5,10 +5,38 @@ local RocketWeapon1Bomber = import('/lua/nomadsweapons.lua').RocketWeapon1Bomber
 
 INA1003 = Class(NAirUnit) {
     Weapons = {
-        Rocket1 = Class(RocketWeapon1Bomber) {},
-        Rocket2 = Class(RocketWeapon1Bomber) {},
-        Rocket3 = Class(RocketWeapon1Bomber) {},
-        Rocket4 = Class(RocketWeapon1Bomber) {},
+        Rocket1 = Class(RocketWeapon1Bomber) {
+            OnGotTarget = function(self)
+                local speed = self:GetVelocity()
+                if speed[1]^2+speed[3]^2 > 3 then
+                    NAirUnit.OnGotTarget(self)
+                end
+            end
+        },
+        Rocket2 = Class(RocketWeapon1Bomber) {
+            OnGotTarget = function(self)
+                local speed = self:GetVelocity()
+                if speed[1]^2+speed[3]^2 > 3 then
+                    NAirUnit.OnGotTarget(self)
+                end
+            end
+        },
+        Rocket3 = Class(RocketWeapon1Bomber) {
+            OnGotTarget = function(self)
+                local speed = self:GetVelocity()
+                if speed[1]^2+speed[3]^2 > 3 then
+                    NAirUnit.OnGotTarget(self)
+                end
+            end
+        },
+        Rocket4 = Class(RocketWeapon1Bomber) {
+            OnGotTarget = function(self)
+                local speed = self:GetVelocity()
+                if speed[1]^2+speed[3]^2 > 3 then
+                    NAirUnit.OnGotTarget(self)
+                end
+            end
+        },
     },
 }
 


### PR DESCRIPTION
prevents hover-bombing by requiring a minimal velocity to activate the weapons.

fixes #218
fixes #271

(needs to be tested though)