### PR TITLE
Fixed T2 Transport Issue

### DIFF
--- a/units/INA2001/INA2001_Script.lua
+++ b/units/INA2001/INA2001_Script.lua
@@ -57,6 +57,7 @@ INA2001 = Class(NAirTransportUnit) {
         if self.UnfoldAnim then
             self.UnfoldAnim:SetRate(0)
         end
+        self:DestroyThrusterEffects()
         NAirTransportUnit.OnKilled(self, instigator, type, overkillRatio)
         self:TransportDetachAllUnits(true)
     end,

--- a/units/INA2001/INA2001_unit.bp
+++ b/units/INA2001/INA2001_unit.bp
@@ -129,6 +129,14 @@ UnitBlueprint {
             '<LOC ability_transport>Transport',
             '<LOC ability_flares>Flares',
         },
+        AnimationDeath = {
+            {
+                Animation = '/units/INA2001/INA2001_Unfold.sca',
+                AnimationRateMax = 1.25,
+                AnimationRateMin = 0.75,
+                Weight = 100,
+            },
+        },
         BuildEffect = {
             ExtendsFront = 0,
             ExtendsRear = 0,


### PR DESCRIPTION
Credit to @Exotic-Retard for pointing out the right direction. Adding a death animation to the transport's BP has fixed the issue with the wreckage. I've also added a line of code to the unit script to destroy the thruster effect when the unit is killed, as it shouldn't still be running when the unit is destroyed. The transport will now fall out of the sky and create a wreckage depending on it's folded position. Fixes #293 