### PR TITLE
fix/ t3 arty adjacency not handled correctly

### DIFF
--- a/units/INA0001/INA0001_unit.bp
+++ b/units/INA0001/INA0001_unit.bp
@@ -33,17 +33,16 @@ UnitBlueprint {
     Description = '<LOC ina0001_desc>Meteor Dropship',
     Display = {
         AnimationOpen = '/units/INA0001/INA0001_AOpen.sca',
-        AnimationSink = '/units/INA0001/INA0001_ASink.sca',
         Mesh = {
             IconFadeInZoom = 2000,
             LODs = {
                 {
-                    AlbedoName = '/Units/INA0001/INA0001_Albedo.dds',
+                    AlbedoName = '/units/INA0001/INA0001_Albedo.dds',
                     LODCutoff = 215,
-                    MeshName = '/Units/INA0001/INA0001_LOD0.scm',
-                    NormalsName = '/UNITS/INA0001/INA0001_NormalsTS.dds',
+                    MeshName = '/units/INA0001/INA0001_Lod0.scm',
+                    NormalsName = '/units/INA0001/INA0001_normalsTS.dds',
                     ShaderName = 'NomadsUnit',
-                    SpecularName = '/Units/INA0001/INA0001_SpecTeam.dds',
+                    SpecularName = '/units/INA0001/INA0001_SpecTeam.dds',
                 },
             },
         },

--- a/units/INB2302/INB2302_script.lua
+++ b/units/INB2302/INB2302_script.lua
@@ -145,11 +145,12 @@ INB2302 = Class(NStructureUnit) {
         self:ForkThread( self.WatchFireState )
     end,
 
+    --oldRoF = 0.05,
     OnArtilleryUnitFired = function(self)
         -- called each time the gun fires a projectile
-        if self.oldRoF ~= self.GetWeaponByLabel('TargetFinder').RateOfFire then
-            self.oldRoF = self.GetWeaponByLabel('TargetFinder').RateOfFire
-            self.ArtilleryUnit:GetWeaponByLabel('MainGun'):ChangeRateOfFire(oldRoF)
+        if self.oldRoF ~= self:GetWeaponByLabel('TargetFinder').RateOfFire then
+            self.oldRoF = self:GetWeaponByLabel('TargetFinder').RateOfFire
+            self.ArtilleryUnit:GetWeaponByLabel('MainGun'):ChangeRateOfFire(self.oldRoF)
         end
     end,
 

--- a/units/INB2302/INB2302_script.lua
+++ b/units/INB2302/INB2302_script.lua
@@ -147,6 +147,10 @@ INB2302 = Class(NStructureUnit) {
 
     OnArtilleryUnitFired = function(self)
         -- called each time the gun fires a projectile
+        if self.oldRoF ~= self.GetWeaponByLabel('TargetFinder').RateOfFire then
+            self.oldRoF = self.GetWeaponByLabel('TargetFinder').RateOfFire
+            self.ArtilleryUnit:GetWeaponByLabel('MainGun'):ChangeRateOfFire(oldRoF)
+        end
     end,
 
     OnArtilleryUnitKilledUnit = function(self, unitKilled)

--- a/units/INO0001/INO0001_unit.bp
+++ b/units/INO0001/INO0001_unit.bp
@@ -39,11 +39,6 @@ UnitBlueprint {
             LODs = {
                 {
                     LODCutoff = 10000,
-                    Scrolling = true,
-                    ShaderName = 'NomadsUnit',
-                },
-                {
-                    LODCutoff = 10000,
                     ShaderName = 'NomadsUnit',
                 },
             },


### PR DESCRIPTION
Adds a callback after firing the satellite that checks if the rate of fire of the arty building was changed (by adjacency for example) from the last time it was fired and adjusts the satellite accordingly

fixes #303